### PR TITLE
Use Release 0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gliderlabs/alpine:3.1
 
 RUN apk-install -t deps wget ca-certificates \
-  && wget -q -O - https://github.com/papertrail/remote_syslog2/releases/download/v0.13/remote_syslog_linux_amd64.tar.gz \
+  && wget -q -O - https://github.com/papertrail/remote_syslog2/releases/download/v0.16/remote_syslog_linux_amd64.tar.gz \
   | tar -zxf - \
   && apk del deps
 


### PR DESCRIPTION
Just moved forward to [the latest](https://github.com/papertrail/remote_syslog2/releases/tag/v0.16).

(Thanks for making this image to begin with!)
